### PR TITLE
Group Tabset for Language Split

### DIFF
--- a/docs/getting_started/editor.qmd
+++ b/docs/getting_started/editor.qmd
@@ -32,7 +32,7 @@ for (x in 1:5) {
 
 ````markdown
 ```{{pyodide}}
-for x in range(5):
+for x in range(1, 6):
   print(10 + x)
 ```
 ````
@@ -54,7 +54,7 @@ for (x in 1:5) {
 # Python
 
 ```{pyodide}
-for x in range(5):
+for x in range(1, 6):
   print(10 + x)
 ```
 

--- a/docs/getting_started/editor.qmd
+++ b/docs/getting_started/editor.qmd
@@ -16,7 +16,7 @@ Add an interactive editor to your Quarto HTML document using the `webr` code cel
 
 #### Source
 
-::: {.panel-tabset}
+::: {.panel-tabset group="language"}
 
 # R
 
@@ -41,11 +41,24 @@ for x in range(5):
 
 #### Output
 
+::: {.panel-tabset group="language"}
+
+# R
+
 ```{webr}
 for (x in 1:5) {
   print(10 + x)
 }
 ```
+
+# Python
+
+```{pyodide}
+for x in range(5):
+  print(10 + x)
+```
+
+:::
 
 ## Read-only cells
 

--- a/docs/getting_started/installation.qmd
+++ b/docs/getting_started/installation.qmd
@@ -49,7 +49,7 @@ Including `_knitr.qmd` is not strictly required if you are using the `jupyter` r
 
 Finally, place R code within a `webr` code blocks and python code within `pyodide` code blocks:
 
-::: {.panel-tabset}
+::: {.panel-tabset group="language"}
 
 ## R
 

--- a/docs/getting_started/packages.qmd
+++ b/docs/getting_started/packages.qmd
@@ -22,7 +22,7 @@ Both webR and Pyodide supports downloading and using additional extension packag
 
 To install packages as part of the document WebAssembly startup process, add a `packages` key to your document's YAML header, under the key corresponding to your chosen WebAssembly engine.
 
-:::: {.panel-tabset}
+:::: {.panel-tabset group="language"}
 
 ## R
 
@@ -56,7 +56,7 @@ pyodide:
 
 Many R and Python packages that are not available from the default webR and Pyodide repositories can still be used with `quarto-live`, with a little extra setup work.
 
-:::: {.panel-tabset}
+:::: {.panel-tabset group="language"}
 
 ## R
 
@@ -96,7 +96,7 @@ pyodide:
 
 ### Interactively
 
-:::: {.panel-tabset}
+:::: {.panel-tabset group="language"}
 
 ## R
 

--- a/docs/getting_started/plotting.qmd
+++ b/docs/getting_started/plotting.qmd
@@ -15,7 +15,7 @@ pyodide:
 
 The `quarto-live` extension prepares the R and Python environment with WebAssembly-compatible graphics devices, and so plotting should work out of the box.
 
-::: {.panel-tabset}
+::: {.panel-tabset group="language"}
 
 ## R
 
@@ -45,7 +45,7 @@ plt.show()
 
 Configure the plot size using the `fig-width` and `fig-height` cell options. Figure size is measured in "inches". Plots are rendered for a given dots-per-inch (DPI) with an internal 2x scaling.
 
-::: {.panel-tabset}
+::: {.panel-tabset group="language"}
 
 ## R
 

--- a/docs/interactive/data.qmd
+++ b/docs/interactive/data.qmd
@@ -22,7 +22,7 @@ bar = ({ x: [1, 2, 3], y: ["a", "b"], z: true });
 baz = [{ a: 1 }, { b: ["x", "y", "z"], c: null }];
 ```
 
-::: {.panel-tabset}
+::: {.panel-tabset group="language"}
 
 ## R
 
@@ -35,6 +35,7 @@ foo
 bar
 baz
 ```
+
 ## Python
 
 ```{pyodide}

--- a/docs/interactive/hybrid.qmd
+++ b/docs/interactive/hybrid.qmd
@@ -17,6 +17,7 @@ Transferring data through OJS variables allows for communication between the dif
 In standard Quarto code cell blocks data can be evaluated at build-time and exported as an [OJS data source](https://quarto.org/docs/interactive/ojs/data-sources.html). The data is then subsequently available to OJS blocks at runtime.
 
 #### Source
+
 ````{.markdown filename="hybrid.qmd"}
 ```{{r}}
 library(ggplot2)
@@ -30,6 +31,7 @@ diamonds
 ````
 
 #### Output
+
 ```{r}
 library(ggplot2)
 head(diamonds)

--- a/docs/interactive/reactivity.qmd
+++ b/docs/interactive/reactivity.qmd
@@ -34,6 +34,7 @@ Before we integrate OJS variables into a `quarto-live` code block, first let's c
 There are many [standard inputs](https://github.com/observablehq/inputs) available through OJS, here we create a set of checkboxes for the variable `islands`.
 
 #### Source
+
 ````{.markdown filename="reactivity.qmd"}
 ```{{ojs}}
 //| echo: false

--- a/docs/other/resources.qmd
+++ b/docs/other/resources.qmd
@@ -27,7 +27,7 @@ Normally `webr` and `pyodide` code blocks are executed in the reader's web brows
 
 To make a file or directory in your local system available under WebAssembly, add the path to the `resources` key in your document's YAML header. The `quarto-live` extension will automatically download named resources into the WebAssembly VFS as R or Python starts up. The resources will be made available in the current working directory (usually `/home/web_user`).
 
-::: {.panel-tabset}
+::: {.panel-tabset group="language"}
 
 ## R
 
@@ -90,7 +90,7 @@ pd.read_csv('data/mtcars.csv')
 
 By default, any resource listed under `resources` will be added to the R and Python VFS. However, you might want to include many resources with your document, but only load a subset of them into the VFS. Use the `resources` key under `webr` and `pyodide` to indicate which resources will be loaded.
 
-::: {.panel-tabset}
+::: {.panel-tabset group="language"}
 
 ## R
 
@@ -127,7 +127,7 @@ Remote resource URLs can be included in the `resources` key, under `webr` and `p
 Resources loaded by URL from a remote server must be served with [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) headers to allow access.
 :::
 
-::: {.panel-tabset}
+::: {.panel-tabset group="language"}
 
 ## R
 


### PR DESCRIPTION
Satisfies part of #19.

I'll likely need to chat with someone over on the Quarto team w.r.t the default language setter. 

I also fixed one of the Python examples under editor to have the correct `for` loop output to match R. 