### PR TITLE
Typo: Match output to example

### DIFF
--- a/docs/interactive/reactivity.qmd
+++ b/docs/interactive/reactivity.qmd
@@ -130,7 +130,7 @@ bar <- rnorm(5)
 ```
 
 ```{{ojs}}
-foo + bar
+d3.sum(foo) + d3.max(bar)
 ```
 ````
 
@@ -145,7 +145,7 @@ bar <- rnorm(5)
 ```
 
 ```{ojs}
-foo + bar
+d3.sum(foo) + d3.max(bar)
 ```
 
 Notice how re-evaluating the code block reactively updates the value calculated in the OJS block.

--- a/docs/interactive/reactivity.qmd
+++ b/docs/interactive/reactivity.qmd
@@ -145,7 +145,7 @@ bar <- rnorm(5)
 ```
 
 ```{ojs}
-d3.sum(foo) + d3.max(bar)
+foo + bar
 ```
 
 Notice how re-evaluating the code block reactively updates the value calculated in the OJS block.


### PR DESCRIPTION
Example code is given as:
````
```{ojs}
foo + bar
```
````

But `echo` of output looks like:
```{ojs}
d3.sum(foo) + d3.max(bar)
```