### PR TITLE
feat: add Quarto Wizard schema and snippets

### DIFF
--- a/_extensions/live/_schema.yml
+++ b/_extensions/live/_schema.yml
@@ -1,0 +1,36 @@
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
+
+formats:
+  live-html:
+    engine:
+      type: string
+      enum: [jupyter, knitr]
+      description: Rendering engine used for live-html documents.
+  live-revealjs:
+    engine:
+      type: string
+      enum: [jupyter, knitr]
+      description: Rendering engine used for live-revealjs slides.
+  live-dashboard:
+    engine:
+      type: string
+      enum: [jupyter, knitr]
+      description: Rendering engine used for live dashboard output.
+
+options:
+  live:
+    type: object
+    description: Runtime toggles for exercise UI features.
+    properties:
+      show-solutions:
+        type: boolean
+        default: true
+        description: Show solution blocks for exercises.
+      show-hints:
+        type: boolean
+        default: true
+        description: Show hint blocks for exercises.
+      grading:
+        type: boolean
+        default: true
+        description: Enable grading checks for exercises.

--- a/_extensions/live/_snippets.json
+++ b/_extensions/live/_snippets.json
@@ -1,0 +1,38 @@
+{
+  "Live HTML setup": {
+    "prefix": "live-html",
+    "body": [
+      "format: live-html"
+    ],
+    "description": "Enable live-html output format."
+  },
+  "Live knitr setup": {
+    "prefix": "live-knitr",
+    "body": [
+      "format: live-html",
+      "engine: knitr",
+      "",
+      "{{< include ./_extensions/r-wasm/live/_knitr.qmd >}}"
+    ],
+    "description": "Configure live-html with knitr setup include."
+  },
+  "Live WebR cell": {
+    "prefix": "webr",
+    "body": [
+      "```{webr}",
+      "${1:summary(lm(mpg ~ am, data = mtcars))}",
+      "```"
+    ],
+    "description": "Insert an interactive WebR code cell."
+  },
+  "Live Pyodide cell": {
+    "prefix": "pyodide",
+    "body": [
+      "```{pyodide}",
+      "${1:import math}",
+      "${2:math.sqrt(16)}",
+      "```"
+    ],
+    "description": "Insert an interactive Pyodide code cell."
+  }
+}


### PR DESCRIPTION
Adds Quarto Wizard support files for this extension to improve authoring and make configuration less error-prone in VSCode/Positron when using Quarto Wizard.

### What this adds
- _extensions/live/_schema.yml with relevant extension metadata for completion and validation.
- _extensions/live/_snippets.json with practical insertion snippets.

### Why this helps
- Better completion and hover guidance for extension-specific configuration.
- Faster setup through reusable snippets.
- Reduced authoring mistakes.

### References
- Schema specification: https://m.canouil.dev/quarto-wizard/reference/schema-specification.html
- Snippet specification: https://m.canouil.dev/quarto-wizard/reference/snippet-specification.html
